### PR TITLE
Small grammar fix

### DIFF
--- a/book/part1/part1_inductives.rst
+++ b/book/part1/part1_inductives.rst
@@ -307,7 +307,7 @@ int { same_case z x }``.
 Lists
 ^^^^^
 
-All the types we've see far have been inductive only in a degenerate
+All the types we've seen so far have been inductive only in a degenerate
 sense—the constructors do not refer to the types they construct. Now,
 for our first truly inductive type, a list.
 


### PR DESCRIPTION
As the title says, this change is just a small grammar fix.

`All the types we’ve see far have been inductive` --> `All the types we’ve seen so far have been inductive`